### PR TITLE
Radarr banned groups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+guessit
+requests


### PR DESCRIPTION
- add checks for banned groups local and remote
- improves accuracy by limiting search to category = movie and type such as remux, encode, etc.
- grammar changes to log messages.